### PR TITLE
cmake: Foreground long running tasks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ else()
             ""
             CONFIGURE_COMMAND
             ""
+            USES_TERMINAL_DOWNLOAD TRUE
             SOURCE_DIR
             ${CMAKE_CURRENT_BINARY_DIR}/linux_out
         )

--- a/docsite/Finddocsite.cmake
+++ b/docsite/Finddocsite.cmake
@@ -30,6 +30,7 @@ macro(docsite_build_site_tar outfile)
         ON
         BUILD_IN_SOURCE
         TRUE
+        USES_TERMINAL_BUILD TRUE
         BUILD_COMMAND
         "make;build"
         INSTALL_COMMAND


### PR DESCRIPTION
Move long running tasks to foreground so that it doesn't appear that the
build has hung.

- Linux downloading takes a while for a git checkout
- The sel4-docsite project can hang while bundler asks for a sudo
  prompt.  There doesn't seem to be a way to dismiss this with a flag.

Signed-off-by: Kent McLeod <kent@kry10.com>