### PR TITLE
fix compilation breakage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,9 +267,9 @@ DeclareCAmkESComponent(VM SOURCES src/cross_vm_connections.c)
 
 # Declare root server
 if(MULTI_VM_LAN)
-    DeclareCAmkESRootserver(multi_main.camkes CPP_INCLUDES ${CAMKES_ARM_VM_DIR}/components/VM)
+    DeclareCAmkESRootserver(multi_main.camkes CPP_INCLUDES ${CAMKES_ARM_VM_DIR}/components/VM_Arm)
 else()
-    DeclareCAmkESRootserver(main.camkes CPP_INCLUDES ${CAMKES_ARM_VM_DIR}/components/VM)
+    DeclareCAmkESRootserver(main.camkes CPP_INCLUDES ${CAMKES_ARM_VM_DIR}/components/VM_Arm)
 endif()
 # Now generate the root server and the global configuration
 GenerateCAmkESRootserver()

--- a/lighttpd/Findlighttpd.cmake
+++ b/lighttpd/Findlighttpd.cmake
@@ -23,7 +23,7 @@ macro(lighttpd_build_server outfile)
     ExternalProject_Add(
         libpcre
         URL
-        https://ftp.pcre.org/pub/pcre/pcre-8.43.tar.gz
+        https://sourceforge.net/projects/pcre/files/pcre/8.43/pcre-8.43.tar.gz
         BINARY_DIR
         ${CMAKE_CURRENT_BINARY_DIR}/libprce-prefix/src/libpcre
         BUILD_ALWAYS


### PR DESCRIPTION
- updates URL for fetch pcre dependency
- adjust for Arm VM now being part of `camkes-vm` repo

This goes together with https://github.com/seL4/sel4webserver-manifest/pull/4 and is in preparation for adding the seL4 webserver repo back into CI (https://github.com/seL4/ci-actions/issues/171).

This should fix #9  and address some of the issues in #8.