### PR TITLE
add CI actions for build + manifest deployment

### DIFF
--- a/.github/workflows/sel4webserver-deploy.yml
+++ b/.github/workflows/sel4webserver-deploy.yml
@@ -1,0 +1,94 @@
+# Copyright 2022, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# seL4 web server demo app regression tests + manifest deployment
+
+name: Web Server Demo
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - '**.md'
+
+  # allow manual trigger
+  workflow_dispatch:
+
+  # allow explict trigger from other repos when dependencies have changed
+  repository_dispatch:
+    types: [deps-update]
+
+jobs:
+  code:
+    name: Freeze Code
+    runs-on: ubuntu-latest
+    outputs:
+      xml: ${{ steps.repo.outputs.xml }}
+    steps:
+    - id: repo
+      uses: seL4/ci-actions/repo-checkout@master
+      with:
+        manifest_repo: sel4webserver-manifest
+        manifest: master.xml
+
+  build:
+    name: Build
+    needs: code
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ODROID_XU4]
+    steps:
+    - uses: seL4/ci-actions/webserver@master
+      with:
+        xml: ${{ needs.code.outputs.xml }}
+        platform: ${{ matrix.platform }}
+    - name: Upload images
+      uses: actions/upload-artifact@v3
+      with:
+        name: images-${{ matrix.platform }}
+        path: '*-images.tar.gz'
+
+  hw-run:
+    name: Hardware
+    runs-on: ubuntu-latest
+    needs: [build]
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ODROID_XU4]
+    # do not run concurrently with other workflows, but do run concurrently in the build matrix
+    concurrency: webserver-hw-${{ strategy.job-index }}
+    steps:
+      - name: Get machine queue
+        uses: actions/checkout@v3
+        with:
+          repository: seL4/machine_queue
+          path: machine_queue
+          token: ${{ secrets.PRIV_REPO_TOKEN }}
+      - name: Download image
+        uses: actions/download-artifact@v3
+        with:
+          name: images-${{ matrix.platform }}
+      - name: Run
+        uses: seL4/ci-actions/webserver-hw@master
+        with:
+          platform: ${{ matrix.platform }}
+          index: $${{ strategy.job-index }}
+        env:
+          HW_SSH: ${{ secrets.HW_SSH }}
+
+  deploy:
+    name: Deploy manifest
+    runs-on: ubuntu-latest
+    needs: [code, hw-run]
+    steps:
+    - name: Deploy
+      uses: seL4/ci-actions/manifest-deploy@master
+      with:
+        xml: ${{ needs.code.outputs.xml }}
+        manifest_repo: sel4webserver-manifest
+      env:
+        GH_SSH: ${{ secrets.CI_SSH }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+# Copyright 2022, Proofcraft Pty Ltd
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+# Build web server demo app on pull request
+
+name: Web Server
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ODROID_XU4]
+    steps:
+    - uses: seL4/ci-actions/webserver@master
+      with:
+        platform: ${{ matrix.platform }}


### PR DESCRIPTION
This will currently build the repo only for the default `odroid_xu4` platform.

Might experiment later with adding at least `qemu_arm_virt`. The `cmake` files seem to be expecting other platforms as well. Does anyone know if these should be working?