### PR TITLE
add build for QEMU

### DIFF
--- a/.github/workflows/sel4webserver-deploy.yml
+++ b/.github/workflows/sel4webserver-deploy.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ODROID_XU4, ODROID_C2, TX2]
+        platform: [ARMVIRT, ODROID_XU4, ODROID_C2, TX2]
     steps:
     - uses: seL4/ci-actions/webserver@master
       with:
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ODROID_XU4, ODROID_C2, TX2]
+        platform: [ARMVIRT, ODROID_XU4, ODROID_C2, TX2]
     # do not run concurrently with other workflows, but do run concurrently in the build matrix
     concurrency: webserver-hw-${{ strategy.job-index }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ODROID_XU4, ODROID_C2, TX2]
+        platform: [ARMVIRT, ODROID_XU4, ODROID_C2, TX2]
     steps:
     - uses: seL4/ci-actions/webserver@master
       with:


### PR DESCRIPTION
Follow-up on https://github.com/seL4/sel4webserver/issues/14 to have a PR that shows the issue

The build fails with 

```
##[group]Run seL4/ci-actions/webserver@master
with:
  platform: ARMVIRT
##[endgroup]
##[command]/usr/bin/docker run --name sel4webserverlatest_5934b8 --label f0efe9 --workdir /github/workspace --rm -e "INPUT_PLATFORM" -e "INPUT_XML" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_REPOSITORY_OWNER_ID" -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" -e "GITHUB_REPOSITORY_ID" -e "GITHUB_ACTOR_ID" -e "GITHUB_ACTOR" -e "GITHUB_TRIGGERING_ACTOR" -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" -e "GITHUB_WORKFLOW_REF" -e "GITHUB_WORKFLOW_SHA" -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" -e "GITHUB_STATE" -e "GITHUB_OUTPUT" -e "RUNNER_OS" -e "RUNNER_ARCH" -e "RUNNER_NAME" -e "RUNNER_ENVIRONMENT" -e "RUNNER_TOOL_CACHE" -e "RUNNER_TEMP" -e "RUNNER_WORKSPACE" -e "ACTIONS_RUNTIME_URL" -e "ACTIONS_RUNTIME_TOKEN" -e "ACTIONS_CACHE_URL" -e "ACTIONS_RESULTS_URL" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/sel4webserver/sel4webserver":"/github/workspace" sel4/webserver:latest

[...]

[374/455] Generating linux_out/.config.old
FAILED: linux_out/.config.old
cd /github/workspace/build/linux_out && bash -c "make oldconfig ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- " && bash -c "make prepare ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- " && bash -c "make modules_prepare ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- "
  HOSTCC  scripts/basic/fixdep
  HOSTCC  scripts/kconfig/conf.o

[...]

scripts/kconfig/conf  --oldconfig Kconfig
#
# configuration written to .config
#
scripts/kconfig/conf  --silentoldconfig Kconfig
  CHK     include/config/kernel.release
  UPD     include/config/kernel.release
  WRAP    arch/arm64/include/generated/asm/bugs.h

[...]

  SHIPPED scripts/dtc/dtc-parser.tab.c
  HOSTCC  scripts/dtc/dtc-parser.tab.o
  HOSTLD  scripts/dtc/dtc
/usr/bin/ld: scripts/dtc/dtc-parser.tab.o:(.bss+0x10): multiple definition of `yylloc'; scripts/dtc/dtc-lexer.lex.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
make[2]: *** [scripts/Makefile.host:110: scripts/dtc/dtc] Error 1
make[1]: *** [scripts/Makefile.build:555: scripts/dtc] Error 2
make: *** [Makefile:571: scripts] Error 2
ninja: build stopped: subcommand failed.
>> command failed, aborting.
-----------[ end test qemu-arm-virt ]-----------
##[endgroup]
qemu-arm-virt FAILED
Successful tests:
FAILED tests: qemu-arm-virt
```