### PR TITLE
github: bump actions to node20

### DIFF
--- a/.github/workflows/sel4webserver-deploy.yml
+++ b/.github/workflows/sel4webserver-deploy.yml
@@ -46,7 +46,7 @@ jobs:
         xml: ${{ needs.code.outputs.xml }}
         platform: ${{ matrix.platform }}
     - name: Upload images
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: images-${{ matrix.platform }}
         path: '*-images.tar.gz'
@@ -63,13 +63,13 @@ jobs:
     concurrency: webserver-hw-${{ strategy.job-index }}
     steps:
       - name: Get machine queue
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: seL4/machine_queue
           path: machine_queue
           token: ${{ secrets.PRIV_REPO_TOKEN }}
       - name: Download image
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: images-${{ matrix.platform }}
       - name: Run


### PR DESCRIPTION
GitHub has started issuing warnings for node16 actions.