### PR TITLE
github: pin Ubuntu 22.04 for deployment step

### DIFF
--- a/.github/workflows/sel4webserver-deploy.yml
+++ b/.github/workflows/sel4webserver-deploy.yml
@@ -82,7 +82,7 @@ jobs:
 
   deploy:
     name: Deploy manifest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [code, hw-run]
     steps:
     - name: Deploy


### PR DESCRIPTION
Python 3.12 in Ubuntu 24.04 has incompatible packages.