### PR TITLE
arm,cmake: Set compiler expected tls settings

### DIFF
--- a/settings.cmake
+++ b/settings.cmake
@@ -92,3 +92,8 @@ ApplyData61ElfLoaderSettings(${KernelARMPlatform} ${KernelSel4Arch})
 
 # Release settings
 ApplyCommonReleaseVerificationSettings(FALSE FALSE)
+
+if (KernelSel4ArchAarch32)
+    # Set correct aarch32 TLS register config
+    set(KernelArmTLSReg tpidruro CACHE STRING "" FORCE)
+endif()


### PR DESCRIPTION
Add the right TLS variable settings for the gnu-elf-abi used by our compilers.